### PR TITLE
Easier process identification

### DIFF
--- a/gazouilleur.service
+++ b/gazouilleur.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=/opt/gazouilleur
 Environment=PYTHONPATH=/opt/gazouilleur
 ExecStart=/opt/gazouilleur/virtualenv/bin/python /opt/gazouilleur/gazouilleur/bot.py
+SyslogIdentifier=gazouilleur
 
 User=gazouilleur
 Group=gazouilleur

--- a/gazouilleur/bot.py
+++ b/gazouilleur/bot.py
@@ -1656,6 +1656,9 @@ ssl_options = ssl.optionsForClientTLS(hostname=config.HOST.decode("utf-8"))
 
 # Run as 'python gazouilleur/bot.py' ...
 if __name__ == '__main__':
+    from setproctitle import setproctitle
+    setproctitle('gazouilleur (%s)' % config.BOTNAME)
+
     if is_ssl(config):
         reactor.connectSSL(config.HOST, config.PORT, IRCBotFactory(), ssl_options)
         #reactor.connectSSL(config.HOST, config.PORT, IRCBotFactory(), ssl.ClientContextFactory())

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ twisted==15.1.0
 stevedore
 virtualenvwrapper
 w3lib==1.12.0
+setproctitle
 
 # Mongo
 pymongo==3.0.3


### PR DESCRIPTION
The two proposed commits will make it easier to identify gazouilleur related events in system monitoring and logs. One by getting `gazouilleur` in log lines instead of `python`. The other by having `gazouilleur (BOTNAME)` in the process list instead of `python`.